### PR TITLE
Fix issue #4

### DIFF
--- a/charts/factorio-server-charts/values.yaml
+++ b/charts/factorio-server-charts/values.yaml
@@ -303,5 +303,6 @@ map_settings:
     - 2
     - 3
     - 4
+    negative_path_cache_delay_interval: 20
   max_failed_behavior_count: 3
     


### PR DESCRIPTION
Error CommandLineMultiplayer.cpp:346: Hosting multiplayer game failed: Key "negative_path_cache_delay_interval" not found in property tree at ROOT.path_finder