### PR TITLE
Fix for issue #4

### DIFF
--- a/charts/factorio-server-charts/values.yaml
+++ b/charts/factorio-server-charts/values.yaml
@@ -303,5 +303,6 @@ map_settings:
     - 2
     - 3
     - 4
+    negative_path_cache_delay_interval: 20
   max_failed_behavior_count: 3
     


### PR DESCRIPTION
As mentioned in the Factorio [forums](https://forums.factorio.com/viewtopic.php?f=11&t=91712&p=522185&hilit=path_cache_delay#p522185), game version 1.1.0 requires `negative_path_cache_delay_interval` to be defined in the `map-settings.json` file, due to the following error: 

```
> Hosting multiplayer game failed: Key "negative_path_cache_delay_interval" not found in property tree at ROOT.path_finder
>    0.916 Info ServerMultiplayerManager.cpp:140: Quitting multiplayer connection.
```
This PR adds the key & default value of 20 to the configMap YAML. 