### PR TITLE
Fix for serverSettings (issue #9)

### DIFF
--- a/charts/factorio-server-charts/values.yaml
+++ b/charts/factorio-server-charts/values.yaml
@@ -106,7 +106,7 @@ factorioServer:
   # Location of the configuration files that are generated
   config_path: /srv
 
-server_settings:
+serverSettings:
   # Your Instance Name
   name: Factorio
   # Your Instance Description


### PR DESCRIPTION
Changes `server_settings` to `serverSettings` in order to fix an issue where the config map would not pull in the updated settings.