### PR TITLE
Disabled Default Mods

### DIFF
--- a/charts/factorio-server-charts/values.yaml
+++ b/charts/factorio-server-charts/values.yaml
@@ -93,18 +93,18 @@ persistence:
 mods:
   enabled: false
 # in order to use the mods portal you will need to specify the username and token in the server_settings.
-  portal:
-    - Krastorio2
-    - StorageTank2_Updated
-    - early-robots
+  portal: []
+#     - Krastorio2
+#     - StorageTank2_Updated
+#     - early-robots
 # unofficial section is meant to just allow you to download and place folders into the mods folder. 
 # we will not check version compatibility automatically with these downloads.
 # you can encounter an error if the file names dont match what the mod is expecting for example
 #Error Util.cpp:83: Failed to load mod "Squeak-Through": Filename of mod 
 # /factorio/mods/Squeak-Through.zip doesn't match the expected Squeak Through_1.8.2.zip (case sensitive!)
-  unofficial:
-    - url: "https://github.com/Suprcheese/Squeak-Through/archive/refs/tags/1.8.2.zip"
-      name: "Squeak Through_1.8.2.zip"
+  unofficial: []
+#     - url: "https://github.com/Suprcheese/Squeak-Through/archive/refs/tags/1.8.2.zip"
+#       name: "Squeak Through_1.8.2.zip"
 
 factorioServer:
   # specify a save name


### PR DESCRIPTION
By default, by enabling mods you also automatically add to the list the mods listed in the default values.yaml. With this commit, I removed the default list by commenting it so that if you enable mods by default the list is empty. Encountered an issue where i enabled mods and added only offial mods, which resulted in "Squeak Through" unofficial was still downloaded because i didn't empty the unofficial list.