### PR TITLE
[BUG][CRITICAL] Urgent Fix - Account not Working

### DIFF
--- a/charts/factorio-server-charts/Chart.yaml
+++ b/charts/factorio-server-charts/Chart.yaml
@@ -20,7 +20,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       labels:
         app: {{ template "factorio-server-charts.fullname" . }}
     spec:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: '1'
       {{- if eq .Values.service.type "NodePort" }}
       hostNetwork: true
       {{- else }}
@@ -65,8 +69,8 @@ spec:
             - name: rcon
               mountPath: /rcon-pw
             {{- end }}
-            {{- if or (.Values.server_settings.accountSecret) (.Values.server_settings.username) }}
-            - name: accountData
+            {{- if or (.Values.account.accountSecret) (.Values.account.username) }}
+            - name: account-data
               mountPath: /account
             {{- end }}
             {{- if or (.Values.serverPassword.game_password) (.Values.serverPassword.passwordSecret) }}
@@ -90,6 +94,10 @@ spec:
               mountPath: /factorio
             - name: {{ template "factorio-server-charts.fullname" . }}-mod-downloader-configmap
               mountPath: /scripts
+            {{- if or (.Values.account.accountSecret) (.Values.account.username) }}
+            - name: account-data
+              mountPath: /account
+            {{- end }}
       {{- end }}
       containers:
       - name: {{ template "factorio-server-charts.fullname" . }}
@@ -100,7 +108,7 @@ spec:
         livenessProbe:
           exec:
             command:
-              - 'ps aux | grep factorio'
+              - '/bin/ps aux | /bin/grep factorio'
           periodSeconds: 10
           initialDelaySeconds: 5
           failureThreshold: 3
@@ -113,8 +121,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
-          {{- if or (.Values.server_settings.accountSecret) (.Values.server_settings.username) }}
-          - name: accountData
+          {{- if or (.Values.account.accountSecret) (.Values.account.username) }}
+          - name: account-data
             mountPath: /account
           {{- end }}
           - name: datadir
@@ -139,11 +147,11 @@ spec:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
       volumes:
-        {{- if or (.Values.server_settings.accountSecret) (.Values.server_settings.username) }}
-        - name: accountData
+        {{- if or (.Values.account.accountSecret) (.Values.account.username) }}
+        - name: account-data
           secret:
-          {{- if .Values.server_settings.accountSecret }}
-            secretName: {{ .Values.server_settings.accountSecret }}
+          {{- if .Values.account.accountSecret }}
+            secretName: {{ .Values.account.accountSecret }}
           {{- else}}
             secretName: {{ template "factorio-server-charts.fullname" . }}-account
           {{- end }}

--- a/charts/factorio-server-charts/templates/mod-downloader-configmap.yaml
+++ b/charts/factorio-server-charts/templates/mod-downloader-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  #credit to the factoriotools/factorio-docker team, most of this logic came from them
+  # credit to the factoriotools/factorio-docker team, most of this logic came from them
   # https://github.com/factoriotools/factorio-docker/blob/master/docker/files/update-mods.sh
   mod-downloader.sh: |
     modDir=/factorio/mods
@@ -56,7 +56,7 @@ data:
         fi
         MOD_INFO_URL="$MOD_BASE_URL/api/mods/$1"
         MOD_INFO_JSON=$(curl --silent "$MOD_INFO_URL")
-        #echo "$MOD_INFO_URL $MOD_INFO_JSON"
+    #    echo "$MOD_INFO_URL $MOD_INFO_JSON"
         if ! echo "$MOD_INFO_JSON" | jq -e .name >/dev/null; then
           print_success "  Custom mod not on $MOD_BASE_URL, skipped."
           return 0
@@ -98,12 +98,15 @@ data:
     for key in "${!unofficialMods[@]}"; do
       downloadUnofficial "${unofficialMods[$key]}" $key
     done
-    {{- if and .Values.server_settings.username .Values.server_settings.token }}
-    echo "server is running version $VERSION"
-    for officialMod in ${officialMods[*]}; do
-    downloadofficial $officialMod $USERNAME $TOKEN
-    done
-    {{- end }}
+
+    if [ -f "/account/username" ]; then
+      if [ -f "/account/token" ]; then
+        echo "server is running version $VERSION"
+        for officialMod in ${officialMods[*]}; do
+          downloadofficial $officialMod $USERNAME $TOKEN
+        done
+      fi
+    fi
 
 
 


### PR DESCRIPTION
I noticed when I tried updating my instance on my server that mods weren't downloading, found a couple more bugs to be urgently fixed.
- Bumped Chart version to 1.1.1
- Added `ndots: 1` to dnsConfig to allow Pod to resolve mods.factorio.com and github.com
- Fixed mod-downloader-configmap, removing obsolete check and adding check for username and token presence based on secret