### PR TITLE
Fixed Game Password Naming

### DIFF
--- a/charts/factorio-server-charts/Chart.yaml
+++ b/charts/factorio-server-charts/Chart.yaml
@@ -20,7 +20,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/factorio-server-charts/ci/nodeport-values.yaml.disabled
+++ b/charts/factorio-server-charts/ci/nodeport-values.yaml.disabled
@@ -1,6 +1,0 @@
-rcon:
-  type: NodePort
-  password: CHANGEMECHANGEME
-
-server_settings:
-  name: "NodePort Test"

--- a/charts/factorio-server-charts/ci/rcon-values.yaml
+++ b/charts/factorio-server-charts/ci/rcon-values.yaml
@@ -7,3 +7,6 @@ service:
 
 server_settings:
   name: "ClusterIP Test"
+
+serverPassword:
+  game_password: 'CHANGEME'

--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
               mountPath: /account
             {{- end }}
             {{- if or (.Values.serverPassword.game_password) (.Values.serverPassword.passwordSecret) }}
-            - name: gamePassword
+            - name: game-password
               mountPath: /gamePassword
             {{- end }}
         {{- if .Values.mods.enabled }}
@@ -166,12 +166,12 @@ spec:
             {{- end }}
         {{- end }}
         {{- if or (.Values.serverPassword.game_password) (.Values.serverPassword.passwordSecret) }}
-        - name: gamePassword
+        - name: game-password
           secret:
             {{- if .Values.serverPassword.passwordSecret }}
             secretName: {{ .Values.serverPassword.passwordSecret }}
             {{- else }}
-            secretName: {{ template "factorio-server-charts.fullname" . }}-account
+            secretName: {{ template "factorio-server-charts.fullname" . }}-password
             {{- end }}
         {{- end }}
         - name: datadir


### PR DESCRIPTION
- Removed unused testing values
- Bumped chart version to `1.1.2`
- Fixed volume naming in deployment.yaml
- Fixed mounted secret used for fetching game password
- Added test to verify game password functionality

Resolves #21 