### PR TITLE
Allow configuring securityContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 ## Changelog
 
+### V1.2.0
+
+#### Non-Breaking Changes
+
+- Added `securityContext` field to values.yaml
+
+### V1.1.2
+
+#### Non-Breaking Changes
+
+- Fixed a bug where the `game-password` volume had an invalid name
+
+### V1.1.1
+
+#### Non-Breaking Changes
+
+- Fixed a bug where the `account-data` volume had an invalid name
+- Extended the pod's DNS config to ensure correct DNS resolution in certain
+  environments
+
 ### V1.1.0
 
 #### Breaking Changes

--- a/charts/factorio-server-charts/Chart.yaml
+++ b/charts/factorio-server-charts/Chart.yaml
@@ -20,7 +20,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -58,8 +58,10 @@ spec:
               chown -vR factorio:factorio /factorio
               chmod -vR 777 /factorio/configs
               ls -alth /factorio
+          {{- with .Values.securityContext }}
           securityContext:
-            runAsUser: 0
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: datadir
               mountPath: /factorio
@@ -87,8 +89,10 @@ spec:
             - |
               mkdir -p /factorio/mods
               bash /scripts/mod-downloader.sh
+          {{- with .Values.securityContext }}
           securityContext:
-            runAsUser: 0
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: datadir
               mountPath: /factorio
@@ -103,8 +107,10 @@ spec:
       - name: {{ template "factorio-server-charts.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
         securityContext:
-          runAsUser: 0
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         livenessProbe:
           exec:
             command:

--- a/charts/factorio-server-charts/values.yaml
+++ b/charts/factorio-server-charts/values.yaml
@@ -8,10 +8,12 @@
 ## @param strategy.type Strategy used to replace old pods
 ## @param tolerations Tolerations for pod assignment
 ## @param affinity Affinity rules for pod assignment
-
+## @param securityContext Useful for fixing file permissions. See official [docs](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 
 replicaCount: 1
 
+securityContext:
+  runAsUser: 0
 
 #### Image Configuration ####
 ## @section Image Parameters


### PR DESCRIPTION
This PR allows the ability to configure the pods' security context.

This is useful when dealing with network shares with recalcitrant permission management like NFS. Also useful for forming hats with tin-foil.