### PR TITLE
Bug fix - game password not being properly set through init container

### DIFF
--- a/charts/factorio-server-charts/Chart.yaml
+++ b/charts/factorio-server-charts/Chart.yaml
@@ -20,7 +20,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
                 fi
               fi
               if [ -f "/gamePassword/game_password" ]; then
-                jq -M --rawfile game_password /gamePassword/game_password '.game_password=(game_password|gsub("[\\n\\t]"; ""))' /factorio/configs/server-settings.json > /tmp/server-settings.json && mv /tmp/server-settings.json /factorio/configs/server-settings.json
+                jq -M --rawfile game_password /gamePassword/game_password '.game_password=($game_password|gsub("[\\n\\t]"; ""))' /factorio/configs/server-settings.json > /tmp/server-settings.json && mv /tmp/server-settings.json /factorio/configs/server-settings.json
               fi
               #sleep 100
               chown -vR factorio:factorio /factorio


### PR DESCRIPTION
Issue was that the game password wasn't being relayed properly through JQ because we were missing a $ on the variable declaration. I tested this deployment locally and it does seem to apply now.  