### PR TITLE
Add flib

### DIFF
--- a/examples/space-exploration/README.md
+++ b/examples/space-exploration/README.md
@@ -19,6 +19,7 @@ mods:
     - equipment-gantry
     - textplates
     - combat-mechanics-overhaul
+    - flib
     - RecipeBook
     # QOL
     - even-distribution


### PR DESCRIPTION
`flib` is a dependency of the `RecipeBook` which the latter does not load without.