### PR TITLE
Adding externalTrafficPolicy

### DIFF
--- a/charts/factorio-server-charts/README.md
+++ b/charts/factorio-server-charts/README.md
@@ -192,13 +192,14 @@ If you do run into any issues with mods, I will try to work with you on finding 
 
 ### Service Parameters
 
-| Name                  | Description                                                                                                                | Value      |
-|-----------------------|----------------------------------------------------------------------------------------------------------------------------|------------|
-| `service.type`        | Factorio service type                                                                                                      | `NodePort` |
-| `service.port`        | Factorio service port                                                                                                      | `31497`    |
-| `service.externalIPs` | If you are able to map an external IP, set it here                                                                         |            |
-| `service.nodePort`    | If you use "type: NodePort" set the port to a value you like in the range of 30000-32767. Leave it blank for a random port |            |
-| `service.annotations` | Additional custom annotations for Factorio service                                                                         | `{}`       |
+| Name                            | Description                                                                                                                | Value      |
+|---------------------------------|----------------------------------------------------------------------------------------------------------------------------|------------|
+| `service.type`                  | Factorio service type                                                                                                      | `NodePort` |
+| `service.port`                  | Factorio service port                                                                                                      | `31497`    |
+| `service.externalIPs`           | If you are able to map an external IP, set it here                                                                         |            |
+| `service.nodePort`              | If you use "type: NodePort" set the port to a value you like in the range of 30000-32767. Leave it blank for a random port |            |
+| `service.annotations`           | Additional custom annotations for Factorio service                                                                         | `{}`       |
+| `service.externalTrafficPolicy` | Traffic policy, "Cluster" or "Local", used for the service                                                                 | `Cluster`  |
 
 ### Persistence Configuration
 

--- a/charts/factorio-server-charts/templates/service.yaml
+++ b/charts/factorio-server-charts/templates/service.yaml
@@ -15,6 +15,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.externalTrafficPolicy}}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
   ports:
     - name: factorio
       targetPort: 34197

--- a/charts/factorio-server-charts/values.yaml
+++ b/charts/factorio-server-charts/values.yaml
@@ -65,6 +65,7 @@ service:
   #   port: 34197
   ## LoadBalancer setup
   # type: LoadBalancer
+  # externalTrafficPolicy: Cluster
   annotations: {}
 
 


### PR DESCRIPTION
This change adds the ability to control the externalTrafficPolicy for the service. This allows for a BGP-advertised IP to target the node that is actually running Factorio and eliminated east-west traffic.