### PR TITLE
add rcon-rest-api container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-### V2.1.1
+### V2.2.0
 
 #### Non-Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### V2.0.3
+
+#### Non-Breaking Changes
+
+- Added support for [nekomeowww/factorio-rcon-api](https://github.com/nekomeowww/factorio-rcon-api) including corresponding fields for values.yaml
+
 ### V2.0.2
 
 #### Non-Breaking Changes

--- a/charts/factorio-server-charts/Chart.yaml
+++ b/charts/factorio-server-charts/Chart.yaml
@@ -20,7 +20,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.1
+version: 2.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/factorio-server-charts/Chart.yaml
+++ b/charts/factorio-server-charts/Chart.yaml
@@ -20,7 +20,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.2
+version: 2.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -143,7 +143,7 @@ spec:
         - name: factorio
           containerPort: 34197
           protocol: UDP
-        - containerPort: 27015
+        - containerPort: {{ .Values.factorioServer.rcon_port | quote }}
           protocol: TCP
         resources:
 {{ toYaml .Values.resources | indent 10 }}
@@ -171,6 +171,8 @@ spec:
           value: {{ .Values.factorioServer.enable_space_age | quote }}
         - name: CONFIG
           value: /factorio/configs
+        - name: RCON_PORT
+          value: {{ .Values.factorioServer.rcon_port | quote }}
 {{- if .Values.rcon_api.enabled }}
       - name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
         image: "{{ .Values.rcon_api.image.repository }}:{{ .Values.rcon_api.image.tag }}"
@@ -196,7 +198,7 @@ spec:
         - name: FACTORIO_RCON_HOST
           value: "localhost"
         - name: FACTORIO_RCON_PORT
-          value: "27015"
+          value: {{ .Values.factorioServer.rcon_port | quote }}
         - name: FACTORIO_RCON_PASSWORD
           {{- if .Values.rcon.passwordSecret }}
           valueFrom:

--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -121,7 +121,7 @@ spec:
               mountPath: /factorio
             - name: {{ template "factorio-server-charts.fullname" . }}-save-importer-configmap
               mountPath: /scripts
-        {{- end }}        
+        {{- end }}
       containers:
       - name: {{ template "factorio-server-charts.fullname" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -171,6 +171,44 @@ spec:
           value: {{ .Values.factorioServer.enable_space_age | quote }}
         - name: CONFIG
           value: /factorio/configs
+{{- if .Values.rcon_api.enabled }}
+      - name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
+        image: "{{ .Values.rcon_api.image.repository }}:{{ .Values.rcon_api.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        livenessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - curl -s localhost:24180/api/v1/factorio/console/command/version | grep -q -E '{"version":".*"}'
+          periodSeconds: 10
+          initialDelaySeconds: 5
+          failureThreshold: 3
+        ports:
+        - name: rcon-api
+          containerPort: 24180
+          protocol: TCP
+        - containerPort: 24181
+          protocol: TCP
+        env:
+        - name: FACTORIO_RCON_HOST
+          value: "localhost"
+        - name: FACTORIO_RCON_PORT
+          value: "27015"
+        - name: FACTORIO_RCON_PASSWORD
+          {{- if .Values.rcon.passwordSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.rcon.passwordSecret }}
+              key: rconpw
+          {{- else }}
+          value: {{ .Values.rcon.password | quote }}
+          {{- end }}
+{{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -208,10 +208,10 @@ spec:
         - pingpong3.factorio.com
         - pingpong4.factorio.com
 {{- end }}
-{{- if .Values.rcon_api.enabled }}
+{{- if .Values.rconAPI.enabled }}
       - name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
-        image: "{{ .Values.rcon_api.image.repository }}:{{ .Values.rcon_api.image.tag }}"
-        imagePullPolicy: {{ .Values.rcon_api.image.pullPolicy }}
+        image: "{{ .Values.rconAPI.image.repository }}:{{ .Values.rconAPI.image.tag }}"
+        imagePullPolicy: {{ .Values.rconAPI.image.pullPolicy }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -174,7 +174,7 @@ spec:
 {{- if .Values.rcon_api.enabled }}
       - name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
         image: "{{ .Values.rcon_api.image.repository }}:{{ .Values.rcon_api.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        imagePullPolicy: {{ .Values.rcon_api.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}

--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -207,6 +207,7 @@ spec:
         - pingpong2.factorio.com
         - pingpong3.factorio.com
         - pingpong4.factorio.com
+{{- end }}
 {{- if .Values.rcon_api.enabled }}
       - name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
         image: "{{ .Values.rcon_api.image.repository }}:{{ .Values.rcon_api.image.tag }}"

--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -143,7 +143,7 @@ spec:
         - name: factorio
           containerPort: 34197
           protocol: UDP
-        - containerPort: {{ .Values.factorioServer.rcon_port | quote }}
+        - containerPort: {{ .Values.factorioServer.rcon_port }}
           protocol: TCP
         resources:
 {{ toYaml .Values.resources | indent 10 }}

--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -180,11 +180,9 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         livenessProbe:
-          exec:
-            command:
-            - sh
-            - -c
-            - curl -s localhost:24180/api/v1/factorio/console/command/version | grep -q -E '{"version":".*"}'
+          httpGet:
+            path: /healthz
+            port: rcon-api
           periodSeconds: 10
           initialDelaySeconds: 5
           failureThreshold: 3

--- a/charts/factorio-server-charts/templates/rcon-api-ingress.yaml
+++ b/charts/factorio-server-charts/templates/rcon-api-ingress.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.rcon_api.enabled .Values.rcon_api.ingress.enabled }}
+{{- if and .Values.rconAPI.enabled .Values.rconAPI.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
   annotations:
-  {{- range $key, $value := .Values.rcon_api.ingress.annotations }}
+  {{- range $key, $value := .Values.rconAPI.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
   labels:
@@ -13,29 +13,29 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  ingressClassName: {{ .Values.rcon_api.ingress.className }}
+  ingressClassName: {{ .Values.rconAPI.ingress.className }}
   rules:
-    - host: {{ .Values.rcon_api.ingress.hostname }}
+    - host: {{ .Values.rconAPI.ingress.hostname }}
       http:
         paths:
           - backend:
               service:
                 name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
                 port:
-                  number: {{ .Values.rcon_api.httpPort }}
+                  number: {{ .Values.rconAPI.httpPort }}
             path: /
             pathType: Prefix
           - backend:
               service:
                 name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
                 port:
-                  number: {{ .Values.rcon_api.grpcPort }}
+                  number: {{ .Values.rconAPI.grpcPort }}
             path: /grpc
             pathType: Prefix
-  {{- if and .Values.rcon_api.ingress.tls.enabled .Values.rcon_api.ingress.tls.secretName }}
+  {{- if and .Values.rconAPI.ingress.tls.enabled .Values.rconAPI.ingress.tls.secretName }}
   tls:
     - hosts:
-        - {{ .Values.rcon_api.ingress.hostname }}
-      secretName: {{ .Values.rcon_api.ingress.tls.secretName }}
+        - {{ .Values.rconAPI.ingress.hostname }}
+      secretName: {{ .Values.rconAPI.ingress.tls.secretName }}
   {{- end }}
 {{- end }}

--- a/charts/factorio-server-charts/templates/rcon-api-ingress.yaml
+++ b/charts/factorio-server-charts/templates/rcon-api-ingress.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.rcon_api.enabled .Values.rcon_api.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
+  annotations:
+  {{- range $key, $value := .Values.rcon_api.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  labels:
+    app: {{ template "factorio-server-charts.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  ingressClassName: {{ .Values.rcon_api.ingress.className }}
+  rules:
+    - host: {{ .Values.rcon_api.ingress.hostname }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
+                port:
+                  number: {{ .Values.rcon_api.httpPort }}
+            path: /
+            pathType: Prefix
+          - backend:
+              service:
+                name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
+                port:
+                  number: {{ .Values.rcon_api.grpcPort }}
+            path: /grpc
+            pathType: Prefix
+  {{- if and .Values.rcon_api.ingress.tls.enabled .Values.rcon_api.ingress.tls.secretName }}
+  tls:
+    - hosts:
+        - {{ .Values.rcon_api.ingress.hostname }}
+      secretName: {{ .Values.rcon_api.ingress.tls.secretName }}
+  {{- end }}
+{{- end }}

--- a/charts/factorio-server-charts/templates/rcon-api-service.yaml
+++ b/charts/factorio-server-charts/templates/rcon-api-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rcon_api.enabled }}
+{{- if .Values.rconAPI.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,24 +9,24 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-  {{- range $key, $value := .Values.rcon_api.serviceAnnotations }}
+  {{- range $key, $value := .Values.rconAPI.serviceAnnotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
-  type: {{ .Values.rcon_api.type }}
+  type: {{ .Values.rconAPI.type }}
   ports:
     - name: http
-      port: {{ .Values.rcon_api.httpPort }}
+      port: {{ .Values.rconAPI.httpPort }}
       targetPort: 24180
-    {{- if eq .Values.rcon_api.type "NodePort" }}
-      nodePort: {{ .Values.rcon_api.httpPort }}
+    {{- if eq .Values.rconAPI.type "NodePort" }}
+      nodePort: {{ .Values.rconAPI.httpPort }}
     {{- end }}
       protocol: TCP
     - name: grpc
-      port: {{ .Values.rcon_api.grpcPort }}
+      port: {{ .Values.rconAPI.grpcPort }}
       targetPort: 24181
-    {{- if eq .Values.rcon_api.type "NodePort" }}
-      nodePort: {{ .Values.rcon_api.grpcPort }}
+    {{- if eq .Values.rconAPI.type "NodePort" }}
+      nodePort: {{ .Values.rconAPI.grpcPort }}
     {{- end }}
       protocol: TCP
   selector:

--- a/charts/factorio-server-charts/templates/rcon-api-service.yaml
+++ b/charts/factorio-server-charts/templates/rcon-api-service.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.rcon_api.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
+  labels:
+    app: {{ template "factorio-server-charts.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+  annotations:
+  {{- range $key, $value := .Values.rcon_api.serviceAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+spec:
+  type: {{ .Values.rcon_api.type }}
+  ports:
+    - name: http
+      port: {{ .Values.rcon_api.httpPort }}
+      targetPort: 24180
+    {{- if eq .Values.rcon_api.type "NodePort" }}
+      nodePort: {{ .Values.rcon_api.httpPort }}
+    {{- end }}
+      protocol: TCP
+    - name: grpc
+      port: {{ .Values.rcon_api.grpcPort }}
+      targetPort: 24181
+    {{- if eq .Values.rcon_api.type "NodePort" }}
+      nodePort: {{ .Values.rcon_api.grpcPort }}
+    {{- end }}
+      protocol: TCP
+  selector:
+    app: {{ template "factorio-server-charts.fullname" . }}
+{{- end }}

--- a/charts/factorio-server-charts/templates/rcon-service.yaml
+++ b/charts/factorio-server-charts/templates/rcon-service.yaml
@@ -17,7 +17,7 @@ spec:
   ports:
     - name: rcon
       port: {{ .Values.rcon.port }}
-      targetPort: {{ .Values.factorioServer.rcon_port | quote }}
+      targetPort: {{ .Values.factorioServer.rcon_port }}
     {{- if eq .Values.rcon.type "NodePort" }}
       nodePort: {{ .Values.rcon.port}}
     {{- end }}

--- a/charts/factorio-server-charts/templates/rcon-service.yaml
+++ b/charts/factorio-server-charts/templates/rcon-service.yaml
@@ -17,7 +17,7 @@ spec:
   ports:
     - name: rcon
       port: {{ .Values.rcon.port }}
-      targetPort: 27015
+      targetPort: {{ .Values.factorioServer.rcon_port | quote }}
     {{- if eq .Values.rcon.type "NodePort" }}
       nodePort: {{ .Values.rcon.port}}
     {{- end }}

--- a/charts/factorio-server-charts/values.yaml
+++ b/charts/factorio-server-charts/values.yaml
@@ -307,6 +307,42 @@ rcon:
   # rcon port
   port: 30100
 
+## @param rcon_api.enabled Enable or disable the RCON API service
+## @param rcon_api.image.repository RCON-API image repository
+## @param rcon_api.image.tag RCON-API image tag (immutable tags are recommended)
+## @param rcon_api.image.pullPolicy RCON-API image pull policy
+## @param rcon_api.type Kubernetes service type for the RCON API (e.g., ClusterIP, NodePort, LoadBalancer)
+## @param rcon_api.serviceAnnotations Annotations to add to the RCON API service
+## @param rcon_api.httpPort Internal port on which the HTTP API for RCON is exposed
+## @param rcon_api.grpcPort Internal port on which the gRPC API for RCON is exposed
+## @param rcon_api.ingress.enabled Enable or disable the Ingress for the RCON API service
+## @param rcon_api.ingress.hostname Hostname for the RCON API Ingress
+## @param rcon_api.ingress.className Ingress class name for selecting the Ingress controller (e.g., nginx, cilium)
+## @param rcon_api.ingress.annotations Additional annotations for the Ingress resource
+## @param rcon_api.ingress.tls.enabled Enable or disable TLS for the Ingress
+## @param rcon_api.ingress.tls.secretName Kubernetes Secret name for TLS certificates used by the Ingress
+rcon_api:
+  enabled: false
+  image:
+    repository: "ghcr.io/nekomeowww/factorio-rcon-api"
+    pullPolicy: Always
+    tag: latest
+  type: ClusterIP
+  serviceAnnotations: {}
+  httpPort: 30110
+  grpcPort: 30111
+
+  ingress:
+    enabled: true
+    hostname: "factorio.example.com"
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    tls:
+      enabled: true
+      secretName: "cert-factorio.example.com"
+
 ## @param map_gen_settings.width Map width in tiles; 0 means infinite
 ## @param map_gen_settings.height Map height in tiles; 0 means infinite
 ## @param map_gen_settings.starting_area Multiplier for biter free zone radius

--- a/charts/factorio-server-charts/values.yaml
+++ b/charts/factorio-server-charts/values.yaml
@@ -344,21 +344,21 @@ rcon:
   # rcon port
   port: 30100
 
-## @param rcon_api.enabled Enable or disable the RCON API service
-## @param rcon_api.image.repository RCON-API image repository
-## @param rcon_api.image.tag RCON-API image tag (immutable tags are recommended)
-## @param rcon_api.image.pullPolicy RCON-API image pull policy
-## @param rcon_api.type Kubernetes service type for the RCON API (e.g., ClusterIP, NodePort, LoadBalancer)
-## @param rcon_api.serviceAnnotations Annotations to add to the RCON API service
-## @param rcon_api.httpPort Internal port on which the HTTP API for RCON is exposed
-## @param rcon_api.grpcPort Internal port on which the gRPC API for RCON is exposed
-## @param rcon_api.ingress.enabled Enable or disable the Ingress for the RCON API service
-## @param rcon_api.ingress.hostname Hostname for the RCON API Ingress
-## @param rcon_api.ingress.className Ingress class name for selecting the Ingress controller (e.g., nginx, cilium)
-## @param rcon_api.ingress.annotations Additional annotations for the Ingress resource
-## @param rcon_api.ingress.tls.enabled Enable or disable TLS for the Ingress
-## @param rcon_api.ingress.tls.secretName Kubernetes Secret name for TLS certificates used by the Ingress
-rcon_api:
+## @param rconAPI.enabled Enable or disable the RCON API service
+## @param rconAPI.image.repository RCON-API image repository
+## @param rconAPI.image.tag RCON-API image tag (immutable tags are recommended)
+## @param rconAPI.image.pullPolicy RCON-API image pull policy
+## @param rconAPI.type Kubernetes service type for the RCON API (e.g., ClusterIP, NodePort, LoadBalancer)
+## @param rconAPI.serviceAnnotations Annotations to add to the RCON API service
+## @param rconAPI.httpPort Internal port on which the HTTP API for RCON is exposed
+## @param rconAPI.grpcPort Internal port on which the gRPC API for RCON is exposed
+## @param rconAPI.ingress.enabled Enable or disable the Ingress for the RCON API service
+## @param rconAPI.ingress.hostname Hostname for the RCON API Ingress
+## @param rconAPI.ingress.className Ingress class name for selecting the Ingress controller (e.g., nginx, cilium)
+## @param rconAPI.ingress.annotations Additional annotations for the Ingress resource
+## @param rconAPI.ingress.tls.enabled Enable or disable TLS for the Ingress
+## @param rconAPI.ingress.tls.secretName Kubernetes Secret name for TLS certificates used by the Ingress
+rconAPI:
   enabled: false
   image:
     repository: "ghcr.io/nekomeowww/factorio-rcon-api"

--- a/charts/factorio-server-charts/values.yaml
+++ b/charts/factorio-server-charts/values.yaml
@@ -377,7 +377,7 @@ rcon_api:
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
       nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     tls:
-      enabled: true
+      enabled: false
       secretName: "cert-factorio.example.com"
 
 ## @param map_gen_settings.width Map width in tiles; 0 means infinite

--- a/charts/factorio-server-charts/values.yaml
+++ b/charts/factorio-server-charts/values.yaml
@@ -145,6 +145,7 @@ mods:
 ## @param factorioServer.generate_new_save Generate a new save if `save_name` is not found
 ## @param factorioServer.update_mods_on_start Update mods on server start
 ## @param factorioServer.load_latest_save Lets the game know if you want to load the latest save
+## @param factorioServer.rcon_port Factorio Server RCON port
 factorioServer:
   # name to use for the save file
   save_name: "replaceMe"
@@ -156,6 +157,10 @@ factorioServer:
   load_latest_save: true
   # enables or disables the mods for DLC Space Age in mod-list.json
   enable_space_age: true
+  # factorio game rcon port
+  # this port setting is typically for internal Kubernetes configuration only, and in most cases, it does not need to be modified.
+  # if it is necessary to change the rcon server port where you connect to it, update the "rcon.port" value accordingly.
+  rcon_port: 27015
 
 import_save:
   # enable save importer
@@ -290,7 +295,7 @@ server_settings:
 ## @param rcon.external Enable RCON external access (deploy RCON service)
 ## @param rcon.type RCON service type
 ## @param rcon.serviceAnnotations RCON service annotations
-## @param rcon.passwordSecret Existing secret containing a `password` data field
+## @param rcon.passwordSecret Existing secret containing a `rconpw` data field
 ## @param rcon.password Password for RCON, ignored if `rcon.passwordSecret` is set
 ## @param rcon.port RCON service external port
 # Password and port for the rcon service
@@ -298,7 +303,7 @@ rcon:
   external: true
   type: LoadBalancer
   serviceAnnotations: {}
-  # Existing secret containing a `password` data field
+  # Existing secret containing a `rconpw` data field
   passwordSecret: ""
 
   # Password for rcon


### PR DESCRIPTION
[nekomeowww/factorio-rcon-api](https://github.com/nekomeowww/factorio-rcon-api)
> Fully implemented wrapper for Factorio headless server console as RESTful and gRPC for easier management through APIs

This is a fairly new project i discovered by chance.
hope you dont mind adding a additional (optional) container which adds so much value (or has the potential to do so).

some quick examples:
```sh
# curl -X GET https://factorio/api/v1/factorio/console/command/version
{"version":"2.0.11"}
# curl -X GET https://factorio/api/v1/factorio/console/command/seed
{"seed":"3508092348"}
# curl -X GET https://factorio/api/v1/factorio/console/command/players
{"players":[{"username":"Players","online":false},{"username":"MYNAME","online":true}]} # '{"username":"Players","online":false}' look bugged to me. i am alone; or am i?
# curl -X GET https://factorio/api/v1/factorio/console/command/evolution
{"evolutionFactor":0.0202,"time":100,"pollution":0,"spawnerKills":0}
# curl -X POST https://factorio/api/v1/factorio/console/command/server-save
{}
# curl -X POST https://factorio/api/v1/factorio/console/command/kick -d '{"username": "nicname","reason": "API Test"}'
{}
```