### PR TITLE
fix hostAliases; lost 'ports' key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### V2.2.1
+
+#### Non-Breaking Changes
+
+- Correct issues in deployment when `rconAPI` and `port_fixer` are used simultaniously.
+- Add missing `ports` key to rconAPI container
+
 ### V2.2.0
 
 #### Non-Breaking Changes

--- a/charts/factorio-server-charts/Chart.yaml
+++ b/charts/factorio-server-charts/Chart.yaml
@@ -20,7 +20,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -175,6 +175,35 @@ spec:
           value: {{ .Values.factorioServer.port | quote }}
         - name: RCON_PORT
           value: {{ .Values.factorioServer.rcon_port | quote }}
+{{- if .Values.rconAPI.enabled }}
+      - name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
+        image: "{{ .Values.rconAPI.image.repository }}:{{ .Values.rconAPI.image.tag }}"
+        imagePullPolicy: {{ .Values.rconAPI.image.pullPolicy }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: rcon-api
+        ports:
+        - name: rcon-api
+          containerPort: 24180
+          protocol: TCP
+        - containerPort: 24181
+          protocol: TCP
+        env:
+        - name: FACTORIO_RCON_HOST
+          value: "localhost"
+        - name: FACTORIO_RCON_PORT
+          value: {{ .Values.factorioServer.rcon_port | quote }}
+        - name: FACTORIO_RCON_PASSWORD
+          {{- if .Values.rcon.passwordSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.rcon.passwordSecret }}
+              key: rconpw
+          {{- else }}
+          value: {{ .Values.rcon.password | quote }}
+          {{- end }}
+{{- end }}
 {{- if .Values.port_fixer.enabled }}
       - name: {{ template "factorio-server-charts.fullname" . }}-port-fixer
         image: "{{ .Values.port_fixer.image.repository }}:{{ .Values.port_fixer.image.tag }}"
@@ -207,34 +236,6 @@ spec:
         - pingpong2.factorio.com
         - pingpong3.factorio.com
         - pingpong4.factorio.com
-{{- end }}
-{{- if .Values.rconAPI.enabled }}
-      - name: {{ template "factorio-server-charts.fullname" . }}-rcon-api
-        image: "{{ .Values.rconAPI.image.repository }}:{{ .Values.rconAPI.image.tag }}"
-        imagePullPolicy: {{ .Values.rconAPI.image.pullPolicy }}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: rcon-api
-        - name: rcon-api
-          containerPort: 24180
-          protocol: TCP
-        - containerPort: 24181
-          protocol: TCP
-        env:
-        - name: FACTORIO_RCON_HOST
-          value: "localhost"
-        - name: FACTORIO_RCON_PORT
-          value: {{ .Values.factorioServer.rcon_port | quote }}
-        - name: FACTORIO_RCON_PASSWORD
-          {{- if .Values.rcon.passwordSecret }}
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.rcon.passwordSecret }}
-              key: rconpw
-          {{- else }}
-          value: {{ .Values.rcon.password | quote }}
-          {{- end }}
 {{- end }}
 {{- if .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
somehow i managed to loose the `ports` keyword.

additionally the `port_fixer` must be the last container because `hostAliases: ` are on one level with `containers:`.
e.g. `hostAliases:` are actually outside of the `containers:` scope.