### PR TITLE
disable port-fixer livenessProbe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### V2.2.2
+
+#### Non-Breaking Changes
+
+- Disabled port-fixer livenessProbe due to reliability issues
+
 ### V2.2.1
 
 #### Non-Breaking Changes

--- a/charts/factorio-server-charts/Chart.yaml
+++ b/charts/factorio-server-charts/Chart.yaml
@@ -20,7 +20,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.1
+version: 2.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -218,13 +218,16 @@ spec:
         - --ip=127.0.0.1
         - --port=34197
         - --remotePort={{ .Values.port_fixer.port | default .Values.service.port }}
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: port-fixer
-          periodSeconds: 10
-          initialDelaySeconds: 5
-          failureThreshold: 3
+        #
+        # Disabled due to reliability issues: https://github.com/ZCube/factorio-port-fixer/issues/1
+        #
+        # livenessProbe:
+        #   httpGet:
+        #     path: /health
+        #     port: port-fixer
+        #   periodSeconds: 10
+        #   initialDelaySeconds: 5
+        #   failureThreshold: 3
         ports:
         - name: port-fixer
           containerPort: 34197


### PR DESCRIPTION
due to reliability issues i have disabled the port-fixer livenessProbe
see: https://github.com/ZCube/factorio-port-fixer/issues/1

fixes: #62 