### PR TITLE
Use `replicaCount` Value in Deployment Template

### DIFF
--- a/charts/factorio-server-charts/templates/deployment.yaml
+++ b/charts/factorio-server-charts/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "factorio-server-charts.fullname" . }}


### PR DESCRIPTION
The configured `replicaCount` value was not used in the deployment config. This PR aims to remediate this issue.