### PR TITLE
Bump chart version to 2.5.3

### DIFF
--- a/charts/factorio-server-charts/Chart.yaml
+++ b/charts/factorio-server-charts/Chart.yaml
@@ -20,7 +20,7 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.5.2
+version: 2.5.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Bump chart version to 2.5.3 to resolve conflicting tag from this change https://github.com/SQLJames/factorio-server-charts/actions/runs/18295988044/job/52094383841

I am playing with graftorio2 and the ability to throw a Prometheus exporter pod in there would be handy. This change just unblocks the release pipeline.